### PR TITLE
Correct version number carried over from old project

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name"            : "eslint-config-walmart",
   "description"     : "A set of default eslint configurations, Walmart Labs style.",
 
-  "version"         : "10.0.0",
+  "version"         : "1.0.0",
   "author"          : "Eric Baer <me@ericbaer.com>",
 
   "homepage"        : "https://github.com/walmartlabs/eslint-config-walmart",


### PR DESCRIPTION
This is a carry over from eslint-config-defaults and since this is not only a brand new project but a project that has NOT been published to npm yet, you should start revving at v1.
