### PR TITLE
[PATCH] Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "repository": "git://github.com/walmartlabs/eslint-config-walmart.git",
   "private": false,
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "babel-eslint": "6.0.4",
     "eslint": "^2.0.0",
     "eslint-plugin-filenames": "1.0.0",


### PR DESCRIPTION
This PR fixes the dependencies on `eslint-config-walmart` that should be included by packages depending on this package by changing the following dependencies from `devDependencies` to `dependencies`:
- `babel-eslint`
- `eslint`
- `eslint-plugin-filenames`
- `eslint-plugin-react`
