### PR TITLE
🔧 [MINOR] Ignore basic numbers in no-magic-numbers rule

### DIFF
--- a/configurations/es5-test.js
+++ b/configurations/es5-test.js
@@ -8,6 +8,7 @@ module.exports = {
     "mocha": true
   },
   "rules": {
-    "max-nested-callbacks": 0
+    "max-nested-callbacks": 0,
+    "no-magic-numbers": 0
   }
 };

--- a/configurations/es6-node-test.js
+++ b/configurations/es6-node-test.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   "rules": {
     "max-nested-callbacks": 0,
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "no-magic-numbers": 0
   }
 };

--- a/configurations/es6-react-test.js
+++ b/configurations/es6-react-test.js
@@ -7,6 +7,7 @@ module.exports = {
     "phantomjs": true
   },
   "rules": {
-    "max-nested-callbacks": 0
+    "max-nested-callbacks": 0,
+    "no-magic-numbers": 0
   }
 };

--- a/configurations/es6-test.js
+++ b/configurations/es6-test.js
@@ -7,6 +7,7 @@ module.exports = {
     "phantomjs": true
   },
   "rules": {
-    "max-nested-callbacks": 0
+    "max-nested-callbacks": 0,
+    "no-magic-numbers": 0
   }
 };

--- a/rules/eslint/best-practices/on.js
+++ b/rules/eslint/best-practices/on.js
@@ -69,7 +69,7 @@ module.exports = {
     // disallow creation of functions within loops
     "no-loop-func": 2,
     // disallow the use of magic numbers
-    "no-magic-numbers": 2,
+    "no-magic-numbers": [2, {"ignore": [-1, 0, 1]}],
     // disallow use of multiple spaces
     "no-multi-spaces": 2,
     // disallow use of multiline strings


### PR DESCRIPTION
Ignoring `-1`, `0` and `1` in the `no-magic-numbers` rule allows iterators, length comparators,
and expect quantities to exist without throwing lint errors.

Turns off `no-magic-numbers` in tests.

cc/ @baer @chaseadamsio @ryan-roemer 
