### PR TITLE
always allow the use of backticks for strings

### DIFF
--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -117,7 +117,7 @@ module.exports = {
     // require quotes around object literal property names
     "quote-props": 0,
     // specify whether double or single quotes should be used
-    "quotes": [2, "double"],
+    "quotes": [2, "double", { "allowTemplateLiterals": true }],
     // Require JSDoc comment
     "require-jsdoc": 0,
     // require or disallow use of semicolons instead of ASI


### PR DESCRIPTION
I hope this one is an easy sell for everyone.  It's kind of silly when you change something like:

```js
console.log(`test ${value}`);
```

to 

```
console.log(`test 100`);
```

you have to change the backticks to `"` or eslint complains.

It also allows you to easily use `"` in strings instead of escaping them.

