### PR TITLE
🔧 [PATCH] Set indent rule Prettier-compatible

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -2499,7 +2499,7 @@
 <a name="whitespace--spaces"></a><a name="12.3"></a>
 - [12.3](#whitespace--spaces) Use soft tabs set to 2 spaces.
 
-  > eslint: [`indent`](http://eslint.org/docs/rules/indent.html), [`no-mixed-spaces-and-tabs`](http://eslint.org/docs/rules/no-mixed-spaces-and-tabs), [`no-trailing-spaces`](http://eslint.org/docs/rules/no-trailing-spaces)
+  > eslint: [`no-mixed-spaces-and-tabs`](http://eslint.org/docs/rules/no-mixed-spaces-and-tabs), [`no-trailing-spaces`](http://eslint.org/docs/rules/no-trailing-spaces)
   >
   > defined in: `rules/eslint/style`
 

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -31,7 +31,7 @@ module.exports = {
     // require identifiers to match the provided regular expression
     "id-match": 0,
     // this option sets a specific tab width for your code
-    "indent": [2, 2],
+    "indent": 0,
     // specify whether double or single quotes should be used in JSX attributes
     "jsx-quotes": [2, "prefer-double"],
     // enforces spacing between keys and values in object literal properties


### PR DESCRIPTION
This PR removes the indent rule to make it Prettier-compatible for switch statements.