### PR TITLE
🔧 [PATCH] Make jsx-indent-props Prettier-compatible

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -4196,10 +4196,6 @@
 <a name="jsx--indent-props"></a><a name="17.15"></a>
 - [17.15](#jsx--indent-props) Multiline props should be indented 2 spaces.
 
-  > eslint: [`react/jsx-indent-props`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md)
-  >
-  > defined in: `rules/react`
-
   ```js
   // bad
   <Button

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -69,7 +69,7 @@ module.exports = {
     // Validate JSX indentation
     "react/jsx-indent": 0,
     // Validate props indentation in JSX
-    "react/jsx-indent-props": [2, 2],
+    "react/jsx-indent-props": 0,
     // Validate JSX has key prop when in array or iterator
     "react/jsx-key": 2,
     // Limit maximum of props on a single line in JSX


### PR DESCRIPTION
This PR fixes a bug with `jsx-indent-props` using ternaries that causes indentation level to be incompatible with Prettier.

Prettier will format ternary components with props as:
```jsx
const MyComponent = isTrue
  ? <MyOtherComponent
      prop={prop}
    />
  : null;
```