### PR TITLE
fix deprecated wrap multilines

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -4237,7 +4237,7 @@
 <a name="jsx--wrap-multilines"></a><a name="17.11"></a>
 - [17.11](#jsx--wrap-multilines) Wrap multiline JSX in parentheses.
 
-  > eslint: [`react/wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
+  > eslint: [`react/jsx-wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
   >
   > defined in: `rules/react`
 

--- a/rules/react/off.js
+++ b/rules/react/off.js
@@ -46,7 +46,7 @@ module.exports = {
     // Enforce propTypes declarations alphabetical sorting
     "sort-prop-types": 0,
     // Prevent missing parentheses around multilines JSX
-    "react/wrap-multilines": 0,
+    "react/jsx-wrap-multilines": 0,
 
     // ========================================================================
     //                                JSX Specific Rules

--- a/rules/react/on.js
+++ b/rules/react/on.js
@@ -46,7 +46,7 @@ module.exports = {
     // Enforce propTypes declarations alphabetical sorting
     "sort-prop-types": 0,
     // Prevent missing parentheses around multilines JSX
-    "react/wrap-multilines": 2,
+    "react/jsx-wrap-multilines": 2,
 
     // ========================================================================
     //                                JSX Specific Rules


### PR DESCRIPTION
The react/wrap-multilines rule is deprecated. Please use the react/jsx-wrap-multilines rule instead.
![screen shot 2017-04-19 at 9 55 14 am](https://cloud.githubusercontent.com/assets/10135897/25192215/3a075c9a-24e7-11e7-92a8-3b76de482b95.png)
