### PR TITLE
[PATCH] Ignore max-len rule for import statements

### DIFF
--- a/docs/styleguide.md
+++ b/docs/styleguide.md
@@ -2744,7 +2744,7 @@
   > Walmart code style preference.
 
 <a name="whitespace--max-len"></a><a name="12.10"></a>
-- [12.10](#whitespace--max-len) Avoid having lines of code that are longer than 100 characters (including whitespace). Note: URLs are exempt from this rule.
+- [12.10](#whitespace--max-len) Avoid having lines of code that are longer than 100 characters (including whitespace). Note: URLs and `import` and `require` statements and  are exempt from this rule.
 
   > eslint: [`max-len`](http://eslint.org/docs/rules/max-len.html)
   >

--- a/rules/eslint/style/on.js
+++ b/rules/eslint/style/on.js
@@ -45,7 +45,7 @@ module.exports = {
     // specify the maximum depth that blocks can be nested
     "max-depth": [2, 4],
     // specify the maximum length of a line in your program
-    "max-len": [2, 100, 2, {"ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("}],
+    "max-len": [2, 100, 2, {"ignoreUrls": true, "ignorePattern": "^(\\s*var\\s.+=\\s*require\\s*\\(|import)"}],
     // specify the maximum depth callbacks can be nested
     "max-nested-callbacks": [2, 3],
     // limits the number of parameters that can be used in the function declaration.


### PR DESCRIPTION
This PR fixes a bug where very long `import` statements cause a `max-len` rule violation.

Lengthy `import` statements are not broken into multiple lines by Prettier as of `v1.4.0`: https://github.com/prettier/prettier/issues/1833

cc/ @jchip 